### PR TITLE
add freebsd support for awin tty

### DIFF
--- a/extras/cmd/awin/tty_freebsd.go
+++ b/extras/cmd/awin/tty_freebsd.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func setNoEcho(tty *os.File) {
+
+	fd := int(tty.Fd())
+
+	termios, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		fmt.Printf("awin: Getting terminal state failed: %s\n", err)
+		return
+	}
+
+	newState := *termios
+	newState.Lflag &^= unix.ECHO
+	newState.Lflag |= unix.ICANON | unix.ISIG
+	newState.Iflag |= unix.ICRNL
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &newState); err != nil {
+		fmt.Printf("awin: Setting terminal state failed: %s\n", err)
+		return
+	}
+}


### PR DESCRIPTION
the following change adds tty support for awin under freebsd which would fix the following error when trying to compile (assuming all dependencies are updated. see below)

```
Building ../extras/cmd/awin
# github.com/jeffwilliams/anvil/extras/cmd/awin
../extras/cmd/awin/tty_unix.go:19:2: undefined: setNoEcho
```


note that i could not fully compile all of the binaries without also updating dependencies for gioui.org to v0.8.0 (see diff below for updates) as the following error would occur:

```
# gioui.org/internuser/vk
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1896:9: cannot define new methods on non-locuser type PushConstantRange
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1900:9: cannot define new methods on non-locuser type PushConstantRange
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1904:9: cannot define new methods on non-locuser type PushConstantRange
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1908:9: cannot define new methods on non-locuser type QueueFamilyProperties
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1912:9: cannot define new methods on non-locuser type SurfaceCapabilities
/home/user/go/pkg/mod/github.com/jeffwilliams/gio@v0.7.2/internuser/vk/vulkan.go:1916:9: cannot define new methods on non-locuser type SurfaceCapabilities
```



diffs to _go.mod/sum_ to let anvil compile on freebsd

```
diff --git a/editor/go.mod b/editor/go.mod
index 5a87edd..a801705 100644
--- a/editor/go.mod
+++ b/editor/go.mod
@@ -13,10 +13,10 @@ replace golang.org/x/crypto => github.com/jeffwilliams/go-x-crypto v0.0.0-202407

 // This is so we can get the commit that fixes unifont, and my change to allow the
 // Command key to be send as a keypress on MacOS
-replace gioui.org => github.com/jeffwilliams/gio v0.7.2
+//replace gioui.org => github.com/jeffwilliams/gio v0.7.2

 require (
-       gioui.org v0.7.1
+       gioui.org v0.8.0
        github.com/alecthomas/chroma v0.10.0
        github.com/alecthomas/chroma/v2 v2.0.0-alpha4
        github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
@@ -39,7 +39,7 @@ require (
        gioui.org/shader v1.0.8 // indirect
        github.com/davecgh/go-spew v1.1.1 // indirect
        github.com/dlclark/regexp2 v1.11.0 // indirect
-       github.com/go-text/typesetting v0.1.2 // indirect
+       github.com/go-text/typesetting v0.2.1 // indirect
        github.com/pmezard/go-difflib v1.0.0 // indirect
        github.com/rivo/uniseg v0.2.0 // indirect
        golang.org/x/exp v0.0.0-20240707233637-46b078467d37 // indirect
diff --git a/editor/go.sum b/editor/go.sum
index cd62bca..efdd2ab 100644
--- a/editor/go.sum
+++ b/editor/go.sum
@@ -1,5 +1,7 @@
 eliasnaur.com/font v0.0.0-20230308162249-dd43949cb42d h1:ARo7NCVvN2NdhLlJE9xAbKweuI9L6UgfTbYb0YwPacY=
 eliasnaur.com/font v0.0.0-20230308162249-dd43949cb42d/go.mod h1:OYVuxibdk9OSLX8vAqydtRPP87PyTFcT9uH3MlEGBQA=
+gioui.org v0.8.0 h1:QV5p5JvsmSmGiIXVYOKn6d9YDliTfjtLlVf5J+BZ9Pg=
+gioui.org v0.8.0/go.mod h1:vEMmpxMOd/iwJhXvGVIzWEbxMWhnMQ9aByOGQdlQ8rc=
 gioui.org/cpu v0.0.0-20210808092351-bfe733dd3334/go.mod h1:A8M0Cn5o+vY5LTMlnRoK3O5kG+rH0kWfJjeKd9QpBmQ=
 gioui.org/cpu v0.0.0-20210817075930-8d6a761490d2 h1:AGDDxsJE1RpcXTAxPG2B4jrwVUJGFDjINIPi1jtO6pc=
 gioui.org/cpu v0.0.0-20210817075930-8d6a761490d2/go.mod h1:A8M0Cn5o+vY5LTMlnRoK3O5kG+rH0kWfJjeKd9QpBmQ=
@@ -23,8 +25,10 @@ github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6
 github.com/flopp/go-findfont v0.1.0/go.mod h1:wKKxRDjD024Rh7VMwoU90i6ikQRCr+JTHB5n4Ejkqvw=
 github.com/go-text/typesetting v0.1.2 h1:KmZOfoxrrYgghohzXgNY7aQPgQ4W+QeKPeRI8yqpDDE=
 github.com/go-text/typesetting v0.1.2/go.mod h1:2+owI/sxa73XA581LAzVuEBZ3WEEV2pXeDswCH/3i1I=
+github.com/go-text/typesetting v0.2.1/go.mod h1:mTOxEwasOFpAMBjEQDhdWRckoLLeI/+qrQeBCTGEt6M=
 github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66 h1:GUrm65PQPlhFSKjLPGOZNPNxLCybjzjYBzjfoBGaDUY=
 github.com/go-text/typesetting-utils v0.0.0-20240317173224-1986cbe96c66/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
+github.com/go-text/typesetting-utils v0.0.0-20241103174707-87a29e9e6066 h1:qCuYC+94v2xrb1PoS4NIDe7DGYtLnU2wWiQe9a1B1c0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jeffwilliams/boyermoore v0.0.0-20220817021623-63ad6ff520f8 h1:ZluQEnWkhVmv80+uMYh2pQCni9gKPvgJMizVIZudZfM=
```


